### PR TITLE
feat: configure traefik routes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,16 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.n8n.rule=Host(`${DOMAIN}`)"
       - "traefik.http.routers.n8n.entrypoints=websecure"
+      - "traefik.http.routers.n8n.tls=true"
+      - "traefik.http.routers.n8n.middlewares=n8n-headers@docker"
       - "traefik.http.routers.n8n.tls.certresolver=myresolver"
+      - "traefik.http.routers.n8n-web.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.n8n-web.entrypoints=web"
+      - "traefik.http.routers.n8n-web.middlewares=redirect@docker"
       - "traefik.http.services.n8n.loadbalancer.server.port=5678"
       - "traefik.http.middlewares.redirect.redirectscheme.scheme=https"
       - "traefik.http.middlewares.n8n-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
       - "traefik.http.middlewares.n8n-headers.headers.customrequestheaders.X-Forwarded-For=true"
-      - "traefik.http.routers.n8n.middlewares=redirect@docker,n8n-headers"
   n8n-postgres:
     image: postgres:15-alpine
     container_name: n8n-postgres


### PR DESCRIPTION
## Summary
- add HTTP router with redirect middleware
- enable TLS and headers middleware on secure router

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68b8506f93808324b6c77dc3d3ab47a4