### PR TITLE
fix: update path for n8n update script

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -103,7 +103,7 @@ bot.onText(/\/update/, (msg) => {
   send('🔄 Начинаю обновление n8n...');
 
   const { exec } = require('child_process');
-  exec('/bin/bash /opt/n8n-install/update_n8n.sh', (error, stdout, stderr) => {
+  exec('/bin/bash /update_n8n.sh', (error, stdout, stderr) => {
     if (error) {
       send(`❌ Обновление завершилось с ошибкой:\n${error.message}`);
       return;


### PR DESCRIPTION
## Summary
- fix Telegram bot update command path to use /update_n8n.sh

## Testing
- `node --check bot/bot.js`
- `npm test` *(fails: Missing script "test")*
- `docker-compose build n8n-bot` *(fails: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68b960bea58083249415d10ebaa59b24